### PR TITLE
Provide list of Entity properties to omit from requests

### DIFF
--- a/odata/service.py
+++ b/odata/service.py
@@ -244,7 +244,7 @@ class ODataService(object):
         """
         return self.default_context.delete(entity)
 
-    def save(self, entity, force_refresh=True):
+    def save(self, entity, force_refresh=True, omit_null_props=[]):
         """
         Creates a POST or PATCH call to the service. If the entity already has
         a primary key, an update is called. Otherwise the entity is inserted
@@ -254,4 +254,4 @@ class ODataService(object):
         :param force_refresh: Read full entity data again from service after PATCH call
         :raises ODataConnectionError: Invalid data or serverside error. Server returned an HTTP error code
         """
-        return self.default_context.save(entity, force_refresh=force_refresh)
+        return self.default_context.save(entity, force_refresh=force_refresh, omit_null_props=omit_null_props)

--- a/odata/state.py
+++ b/odata/state.py
@@ -188,10 +188,10 @@ class EntityState(object):
         if prop.name not in self.dirty:
             self.dirty.append(prop.name)
 
-    def data_for_insert(self):
-        return self._clean_new_entity(self.entity)
+    def data_for_insert(self, omit_null_props=[]):
+        return self._clean_new_entity(self.entity, omit_null_props)
 
-    def data_for_update(self):
+    def data_for_update(self, omit_null_props=[]):
         update_data = OrderedDict()
         update_data['@odata.type'] = self.entity.__odata_type__
 
@@ -211,9 +211,19 @@ class EntityState(object):
                         update_data[key] = [i.__odata__.id for i in value]
                     else:
                         update_data[key] = value.__odata__.id
-        return update_data
+        
+        update_data_filtered = {}
+        for prop_name, prop in update_data.items():
+            if omit_null_props is True or prop_name in omit_null_props:
+                # Should omit unless not None
+                if prop is None:
+                    # Omit from request
+                    continue
+                update_data_filtered[prop_name] = prop
 
-    def _clean_new_entity(self, entity):
+        return update_data_filtered
+
+    def _clean_new_entity(self, entity, omit_null_props=[]):
         """:type entity: odata.entity.EntityBase """
         insert_data = OrderedDict()
         insert_data['@odata.type'] = entity.__odata_type__
@@ -262,4 +272,13 @@ class EntityState(object):
                     else:
                         insert_data[prop.name] = self._clean_new_entity(value)
 
-        return insert_data
+        insert_data_filtered = {}
+        for prop_name, prop in insert_data.items():
+            if omit_null_props is True or prop_name in omit_null_props:
+                # Should omit unless not None
+                if prop is None:
+                    # Omit from request
+                    continue
+                insert_data_filtered[prop_name] = prop
+
+        return insert_data_filtered


### PR DESCRIPTION
Some odata services expose Entity properties which are sometimes read-only, and passing the default (`None`) value causes the service to return an error. This patch implements an additional keyword argument (`omit_null_props`) passed to `save()` to provide a list of attributes to be explicitly omitted from the request payload if they are null. Optionally, `omit_null_props` may be set to `True`,  and all properties with value None will be omitted from the request. Applies to POST and PATCH requests.